### PR TITLE
fix: let PWA on Android display in landscape mode

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#2d2d2e",
-  "orientation": "portrait-primary",
+  "orientation": "any",
   "scope": "/",
   "icons": [
     {


### PR DESCRIPTION
## Description
Right now on my Android tablet, the app doesn't rotate when I turn the physical tablet.

## Type of Change
- [x] 🐛 Bug fix (fix)
