### PR TITLE
chore(pwa): bump cache version to v4 for 7-day timeline view

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // Increment CACHE_NAME when making breaking cache changes
-const CACHE_VERSION = 'fp-calendar-v3';
+const CACHE_VERSION = 'fp-calendar-v4';
 const CACHE_NAME = `${CACHE_VERSION}`;
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
Force browsers to fetch new JavaScript after 7-day feature deployment.