### PR TITLE
chore: fix notion sync

### DIFF
--- a/src/hooks/useNotionScrapedCalendars.tsx
+++ b/src/hooks/useNotionScrapedCalendars.tsx
@@ -16,8 +16,18 @@ import type { PageObjectResponse, DatabaseObjectResponse } from '@notionhq/clien
 import { notionPageScraper } from '@/services/NotionPageScraper';
 import { RateLimiter, createDebounce } from '@/lib/rateLimiter';
 import { CalendarRefreshUtils } from '@/hooks/useCalendarRefresh';
+import { format, startOfWeek } from 'date-fns';
 
 import { useBackgroundSync } from './useBackgroundSync';
+
+const NOTION_DATE_PROPERTY = 'Date';
+
+export const buildCurrentWeekDateFilter = (now: Date = new Date()) => ({
+  property: NOTION_DATE_PROPERTY,
+  date: {
+    on_or_after: format(startOfWeek(now, { weekStartsOn: 0 }), 'yyyy-MM-dd'),
+  },
+});
 
 // Narrowed property fragment types to avoid any usage
 interface NotionRichTextFragment { plain_text?: string }
@@ -64,7 +74,6 @@ export const useNotionScrapedCalendars = () => {
   const debouncedSyncRef = useState(() => new Map<string, ReturnType<typeof createDebounce>>())[0];
   const RETRY_QUEUE_KEY = 'notion_sync_retry_queue';
   const SETUP_ATTEMPT_KEY = 'notion_setup_last_attempt';
-  const LAST_EDITED_SAFETY_MS = 5 * 60 * 1000;
   
   const { 
     registerBackgroundSync, 
@@ -73,19 +82,6 @@ export const useNotionScrapedCalendars = () => {
     isBackgroundSyncSupported,
     processSyncQueue
   } = useBackgroundSync();
-
-  const buildIncrementalFilter = useCallback((lastSuccessfulSync?: string) => {
-    if (!lastSuccessfulSync) return undefined;
-    const last = new Date(lastSuccessfulSync).getTime();
-    if (Number.isNaN(last)) return undefined;
-    const after = new Date(Math.max(0, last - LAST_EDITED_SAFETY_MS)).toISOString();
-    return {
-      timestamp: 'last_edited_time',
-      last_edited_time: {
-        after
-      }
-    };
-  }, []);
 
   const recordSetupAttempt = useCallback((payload: { url: string; result: 'success' | 'error'; error?: string; code?: string }) => {
     try {
@@ -360,19 +356,10 @@ export const useNotionScrapedCalendars = () => {
         }));
       } else {
         // Direct Notion API fully paginated query
-        const incrementalFilter = buildIncrementalFilter(calendar.lastSuccessfulSync);
-        const pages = await notionAPIClient.queryAllWithOptions(
+        const pages = await notionAPIClient.queryAll(
           calendar.metadata.databaseId!,
           calendar.metadata.token!,
-          {
-            filter: incrementalFilter,
-            startCursor: calendar.lastSyncCursor,
-            onPage: async (res) => {
-              if (res.next_cursor) {
-                await updateCalendar(calendar.id, { lastSyncCursor: res.next_cursor });
-              }
-            }
-          }
+          buildCurrentWeekDateFilter()
         );
         apiEvents = transformPages(pages as PageObjectResponse[]);
       }
@@ -541,6 +528,12 @@ export const useNotionScrapedCalendars = () => {
       console.error('Error syncing calendar:', error);
       setSyncStatus(prev => ({ ...prev, [calendar.id]: 'error' }));
 
+      try {
+        await updateCalendar(calendar.id, { lastSyncCursor: undefined });
+      } catch (cursorError) {
+        console.warn('Failed to clear stale Notion sync cursor', cursorError);
+      }
+
       if (error instanceof NotionApiError) {
         if (error.code === 'cors_blocked' || error.code === 'network' || error.code === 'timeout') {
           enqueueRetry(calendar.id);
@@ -558,7 +551,7 @@ export const useNotionScrapedCalendars = () => {
 
       throw error;
     }
-  }, [buildIncrementalFilter, enqueueRetry, getDatabaseMetadata, loadEvents, toast, transformPages, updateCalendar]);
+  }, [enqueueRetry, getDatabaseMetadata, loadEvents, toast, transformPages, updateCalendar]);
 
   // Public API with rate limiting + per-calendar debounce
   const syncCalendar = useCallback(async (calendar: NotionScrapedCalendar) => {

--- a/src/test/hooks/useNotionScrapedCalendars.test.ts
+++ b/src/test/hooks/useNotionScrapedCalendars.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { buildCurrentWeekDateFilter } from '@/hooks/useNotionScrapedCalendars';
+
+describe('buildCurrentWeekDateFilter', () => {
+  it('filters from Sunday at the start of the current week', () => {
+    const filter = buildCurrentWeekDateFilter(new Date(2026, 7, 11, 15, 30));
+
+    expect(filter).toEqual({
+      property: 'Date',
+      date: {
+        on_or_after: '2026-08-09',
+      },
+    });
+  });
+
+  it('keeps the current date when syncing on Sunday', () => {
+    const filter = buildCurrentWeekDateFilter(new Date(2026, 7, 9, 23, 59));
+
+    expect(filter.date.on_or_after).toBe('2026-08-09');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace incremental Notion queries with full paginated queries to prevent empty responses from clearing stored events.
- Remove persisted pagination cursor resumption and clear stale cursors after failed syncs.
- Limit synced entries to the current week, starting Sunday, and future dates.
- Use local date formatting to avoid timezone boundary shifts.
- Add tests covering weekday and Sunday filter boundaries.

## Root cause

Incremental queries returned only recently edited entries. When no entries had changed, Notion returned an empty successful response. The sync then treated that response as the complete dataset and deleted all previously stored events.

## Test plan

- [x] Run the complete unit test suite: 99 tests passed.
- [x] Run the production build.
- [x] Check edited files for lint errors.
- [x] Verify the current-week filter starts on Sunday.
- [ ] Verify a connected Notion calendar retains events across consecutive syncs.
- [ ] Confirm entries before the current week are removed and future entries remain visible.

## Notes

The Notion date property is currently expected to be named `Date`.