### PR TITLE
feat: add export and import

### DIFF
--- a/src/components/LocalDataManager.tsx
+++ b/src/components/LocalDataManager.tsx
@@ -1,15 +1,17 @@
 
 import React, { useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import { Download, Upload, Trash2, HardDrive, Info } from 'lucide-react';
+import { Download, Upload, Trash2, HardDrive, Info, AlertTriangle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { localDataManager } from '@/utils/localDataManager';
+import { calendarConfigManager } from '@/utils/calendarConfigManager';
 import { InfoBanner, InfoBannerContent, InfoBannerDescription, InfoBannerIcon, InfoBannerTitle } from '@/components/ui/info-banner';
 import { Progress } from '@/components/ui/progress';
 import SettingsSectionCard from '@/components/settings/SettingsSectionCard';
 
 const LocalDataManager = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const configFileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
 
   const handleExport = async () => {
@@ -51,6 +53,46 @@ const LocalDataManager = () => {
     // Clear the input
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
+    }
+  };
+
+  const handleConfigExport = async () => {
+    try {
+      await calendarConfigManager.exportCalendarConfig();
+      toast({
+        title: "Configuration exported",
+        description: "Your calendar URLs and Notion settings have been downloaded.",
+      });
+    } catch {
+      toast({
+        title: "Configuration export failed",
+        description: "Failed to export your calendar configuration. Please try again.",
+        variant: "destructive"
+      });
+    }
+  };
+
+  const handleConfigImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      await calendarConfigManager.importCalendarConfig(file);
+      toast({
+        title: "Configuration imported",
+        description: "Your calendar URLs and Notion settings have been restored.",
+      });
+      setTimeout(() => window.location.reload(), 1000);
+    } catch (error) {
+      toast({
+        title: "Configuration import failed",
+        description: error instanceof Error ? error.message : "Failed to import configuration.",
+        variant: "destructive"
+      });
+    }
+
+    if (configFileInputRef.current) {
+      configFileInputRef.current.value = '';
     }
   };
 
@@ -136,6 +178,55 @@ const LocalDataManager = () => {
           onChange={handleImport}
           className="hidden"
         />
+
+        <div className="space-y-3 border-t border-gray-200 pt-4 dark:border-gray-700">
+          <div>
+            <h3 className="text-sm font-medium">Calendar configuration</h3>
+            <p className="text-sm text-muted-foreground">
+              Transfer calendar URLs and Notion API settings without exporting event data.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Button
+              onClick={handleConfigExport}
+              variant="outline"
+              className="flex items-center gap-2"
+            >
+              <Download className="h-4 w-4" />
+              Export Config
+            </Button>
+            <Button
+              onClick={() => configFileInputRef.current?.click()}
+              variant="outline"
+              className="flex items-center gap-2"
+            >
+              <Upload className="h-4 w-4" />
+              Import Config
+            </Button>
+          </div>
+
+          <input
+            ref={configFileInputRef}
+            type="file"
+            accept=".json,application/json"
+            onChange={handleConfigImport}
+            className="hidden"
+          />
+
+          <InfoBanner variant="warning">
+            <InfoBannerIcon>
+              <AlertTriangle className="h-4 w-4" />
+            </InfoBannerIcon>
+            <InfoBannerContent>
+              <InfoBannerTitle>Keep configuration files private</InfoBannerTitle>
+              <InfoBannerDescription>
+                Exported files contain calendar URLs and Notion API tokens in plain text.
+                Importing replaces your current calendar configuration.
+              </InfoBannerDescription>
+            </InfoBannerContent>
+          </InfoBanner>
+        </div>
 
         <InfoBanner variant="info">
           <InfoBannerIcon>

--- a/src/services/calendarStorage.ts
+++ b/src/services/calendarStorage.ts
@@ -117,6 +117,32 @@ class CalendarStorageService {
     });
   }
 
+  async clearAllCalendars(): Promise<void> {
+    if (!this.db) await this.init();
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.storeName], 'readwrite');
+      transaction.objectStore(this.storeName).clear();
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async replaceAllCalendars(calendars: CalendarFeed[]): Promise<void> {
+    if (!this.db) await this.init();
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([this.storeName], 'readwrite');
+      const store = transaction.objectStore(this.storeName);
+
+      store.clear();
+      calendars.forEach(calendar => store.put(calendar));
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
   /** Drain items queued by the service worker; used for background iCal sync handoff. */
   async drainBackgroundSyncQueue(): Promise<unknown[]> {
     if (!this.db) await this.init();

--- a/src/services/notionScrapedEventsStorage.ts
+++ b/src/services/notionScrapedEventsStorage.ts
@@ -159,6 +159,21 @@ class NotionScrapedEventsStorage {
     });
   }
 
+  async replaceAllCalendars(calendars: NotionScrapedCalendar[]): Promise<void> {
+    const db = await this.ensureDB();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([CALENDARS_STORE, EVENTS_STORE], 'readwrite');
+      const calendarsStore = transaction.objectStore(CALENDARS_STORE);
+
+      calendarsStore.clear();
+      transaction.objectStore(EVENTS_STORE).clear();
+      calendars.forEach(calendar => calendarsStore.put(calendar));
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
   // Enhanced event management methods
   async saveEvents(calendarId: string, events: NotionScrapedEvent[]): Promise<void> {
     const db = await this.ensureDB();

--- a/src/test/utils/calendarConfigManager.test.ts
+++ b/src/test/utils/calendarConfigManager.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getICalCalendars: vi.fn(),
+  replaceICalCalendars: vi.fn(),
+  getNotionCalendars: vi.fn(),
+  replaceNotionCalendars: vi.fn(),
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+  removeSetting: vi.fn(),
+}));
+
+vi.mock('@/services/calendarStorage', () => ({
+  calendarStorageService: {
+    getAllCalendars: mocks.getICalCalendars,
+    replaceAllCalendars: mocks.replaceICalCalendars,
+  },
+}));
+
+vi.mock('@/services/notionScrapedEventsStorage', () => ({
+  notionScrapedEventsStorage: {
+    getAllCalendars: mocks.getNotionCalendars,
+    replaceAllCalendars: mocks.replaceNotionCalendars,
+  },
+}));
+
+vi.mock('@/services/settingsStorageService', () => ({
+  settingsStorageService: {
+    getValue: mocks.getSetting,
+    setValue: mocks.setSetting,
+    removeValue: mocks.removeSetting,
+  },
+}));
+
+import {
+  calendarConfigManager,
+  parseCalendarConfig,
+  sanitizeNotionCalendar,
+} from '@/utils/calendarConfigManager';
+import { NotionScrapedCalendar } from '@/types/notion';
+
+const validConfig = {
+  type: 'family-calendar-config',
+  version: '1.0',
+  exportDate: '2026-08-11T12:00:00.000Z',
+  icalCalendars: [
+    {
+      id: 'ical-1',
+      name: 'Family',
+      url: 'https://example.com/family.ics',
+      color: '#123456',
+      enabled: true,
+      syncFrequencyPerDay: 4,
+    },
+  ],
+  notionCalendars: [
+    {
+      id: 'notion-1',
+      name: 'Plans',
+      url: 'https://notion.so/example',
+      color: '#abcdef',
+      enabled: true,
+      type: 'notion-scraped',
+      connectionMode: 'api',
+      metadata: {
+        url: 'https://notion.so/example',
+        title: 'Plans',
+        token: 'secret-token',
+        databaseId: 'database-id',
+      },
+    },
+  ],
+  settings: {
+    notionToken: 'global-token',
+    notionDatabaseId: null,
+  },
+  selectedCalendarIds: ['ical-1', 'notion-1'],
+} as const;
+
+describe('calendarConfigManager', () => {
+  beforeEach(() => {
+    mocks.replaceICalCalendars.mockResolvedValue(undefined);
+    mocks.replaceNotionCalendars.mockResolvedValue(undefined);
+    mocks.setSetting.mockResolvedValue(undefined);
+    mocks.removeSetting.mockResolvedValue(undefined);
+  });
+
+  it('validates supported configuration files', () => {
+    expect(parseCalendarConfig(validConfig)).toEqual(validConfig);
+    expect(() => parseCalendarConfig({ ...validConfig, version: '2.0' })).toThrow(
+      'Invalid or unsupported'
+    );
+    expect(() =>
+      parseCalendarConfig({
+        ...validConfig,
+        icalCalendars: [...validConfig.icalCalendars, validConfig.icalCalendars[0]],
+      })
+    ).toThrow('duplicate calendar IDs');
+  });
+
+  it('strips transient Notion sync state from exported calendars', () => {
+    const calendar: NotionScrapedCalendar = {
+      ...validConfig.notionCalendars[0],
+      metadata: {
+        ...validConfig.notionCalendars[0].metadata,
+        lastScraped: new Date(),
+        eventCount: 12,
+      },
+      lastSync: 'yesterday',
+      lastSuccessfulSync: 'yesterday',
+      lastSyncCursor: 'cursor',
+      eventCount: 12,
+      lastSetupAttempt: 'today',
+      lastSetupResult: 'error',
+      lastSetupError: 'network error',
+    };
+
+    expect(sanitizeNotionCalendar(calendar)).toEqual(validConfig.notionCalendars[0]);
+  });
+
+  it('replaces calendars and restores Notion settings and selection on import', async () => {
+    const file = {
+      text: vi.fn().mockResolvedValue(JSON.stringify(validConfig)),
+    } as unknown as File;
+
+    await calendarConfigManager.importCalendarConfig(file);
+
+    expect(mocks.replaceICalCalendars).toHaveBeenCalledWith(validConfig.icalCalendars);
+    expect(mocks.replaceNotionCalendars).toHaveBeenCalledWith([
+      {
+        ...validConfig.notionCalendars[0],
+        metadata: {
+          ...validConfig.notionCalendars[0].metadata,
+          lastScraped: new Date(0),
+          eventCount: 0,
+        },
+      },
+    ]);
+    expect(mocks.setSetting).toHaveBeenCalledWith('notion_token', 'global-token');
+    expect(mocks.removeSetting).toHaveBeenCalledWith('notion_database_id');
+    expect(localStorage.getItem('selectedCalendarIds')).toBe(
+      JSON.stringify(validConfig.selectedCalendarIds)
+    );
+  });
+});

--- a/src/utils/calendarConfigManager.ts
+++ b/src/utils/calendarConfigManager.ts
@@ -1,0 +1,244 @@
+import { calendarStorageService, CalendarFeed } from '@/services/calendarStorage';
+import { notionScrapedEventsStorage } from '@/services/notionScrapedEventsStorage';
+import { settingsStorageService } from '@/services/settingsStorageService';
+import { NotionPageMetadata, NotionScrapedCalendar } from '@/types/notion';
+import { safeLocalStorage } from '@/utils/storage/safeLocalStorage';
+
+const CONFIG_TYPE = 'family-calendar-config';
+const CONFIG_VERSION = '1.0';
+const SELECTED_CALENDARS_KEY = 'selectedCalendarIds';
+const NOTION_TOKEN_KEY = 'notion_token';
+const NOTION_DATABASE_ID_KEY = 'notion_database_id';
+
+type PortableNotionMetadata = Omit<NotionPageMetadata, 'lastScraped' | 'eventCount'>;
+type PortableNotionCalendar = Omit<
+  NotionScrapedCalendar,
+  | 'lastSync'
+  | 'lastSuccessfulSync'
+  | 'lastSyncCursor'
+  | 'eventCount'
+  | 'lastSetupAttempt'
+  | 'lastSetupResult'
+  | 'lastSetupError'
+  | 'metadata'
+> & {
+  metadata?: PortableNotionMetadata;
+};
+
+export interface CalendarConfigFile {
+  type: typeof CONFIG_TYPE;
+  version: typeof CONFIG_VERSION;
+  exportDate: string;
+  icalCalendars: CalendarFeed[];
+  notionCalendars: PortableNotionCalendar[];
+  settings: {
+    notionToken: string | null;
+    notionDatabaseId: string | null;
+  };
+  selectedCalendarIds?: string[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasStringProperties = (value: unknown, properties: string[]): value is Record<string, unknown> =>
+  isRecord(value) && properties.every(property => typeof value[property] === 'string');
+
+const hasUniqueIds = (items: Array<{ id: string }>): boolean =>
+  new Set(items.map(item => item.id)).size === items.length;
+
+export const sanitizeICalCalendar = (calendar: CalendarFeed): CalendarFeed => {
+  const { lastSync: _lastSync, eventCount: _eventCount, ...config } = calendar;
+  return config;
+};
+
+export const sanitizeNotionCalendar = (
+  calendar: NotionScrapedCalendar
+): PortableNotionCalendar => {
+  const {
+    lastSync: _lastSync,
+    lastSuccessfulSync: _lastSuccessfulSync,
+    lastSyncCursor: _lastSyncCursor,
+    eventCount: _eventCount,
+    lastSetupAttempt: _lastSetupAttempt,
+    lastSetupResult: _lastSetupResult,
+    lastSetupError: _lastSetupError,
+    metadata,
+    ...config
+  } = calendar;
+
+  if (!metadata) return config;
+
+  const {
+    lastScraped: _lastScraped,
+    eventCount: _metadataEventCount,
+    ...portableMetadata
+  } = metadata;
+
+  return { ...config, metadata: portableMetadata };
+};
+
+const validateICalCalendar = (value: unknown): value is CalendarFeed =>
+  hasStringProperties(value, ['id', 'name', 'url', 'color']) &&
+  typeof value.enabled === 'boolean' &&
+  (value.syncFrequencyPerDay === undefined || typeof value.syncFrequencyPerDay === 'number');
+
+const validateNotionCalendar = (value: unknown): value is PortableNotionCalendar => {
+  if (
+    !hasStringProperties(value, ['id', 'name', 'url', 'color', 'type']) ||
+    value.type !== 'notion-scraped' ||
+    typeof value.enabled !== 'boolean'
+  ) {
+    return false;
+  }
+
+  if (
+    value.connectionMode !== undefined &&
+    value.connectionMode !== 'api' &&
+    value.connectionMode !== 'public'
+  ) {
+    return false;
+  }
+
+  return value.metadata === undefined || isRecord(value.metadata);
+};
+
+export const parseCalendarConfig = (value: unknown): CalendarConfigFile => {
+  if (!isRecord(value) || value.type !== CONFIG_TYPE || value.version !== CONFIG_VERSION) {
+    throw new Error('Invalid or unsupported calendar configuration file.');
+  }
+
+  if (!Array.isArray(value.icalCalendars) || !value.icalCalendars.every(validateICalCalendar)) {
+    throw new Error('The configuration contains invalid iCal calendars.');
+  }
+
+  if (
+    !Array.isArray(value.notionCalendars) ||
+    !value.notionCalendars.every(validateNotionCalendar)
+  ) {
+    throw new Error('The configuration contains invalid Notion calendars.');
+  }
+
+  if (
+    !hasUniqueIds(value.icalCalendars) ||
+    !hasUniqueIds(value.notionCalendars)
+  ) {
+    throw new Error('The configuration contains duplicate calendar IDs.');
+  }
+
+  if (!isRecord(value.settings)) {
+    throw new Error('The configuration contains invalid Notion settings.');
+  }
+
+  const { notionToken, notionDatabaseId } = value.settings;
+  if (
+    (notionToken !== null && typeof notionToken !== 'string') ||
+    (notionDatabaseId !== null && typeof notionDatabaseId !== 'string')
+  ) {
+    throw new Error('The configuration contains invalid Notion settings.');
+  }
+
+  if (
+    value.selectedCalendarIds !== undefined &&
+    (!Array.isArray(value.selectedCalendarIds) ||
+      !value.selectedCalendarIds.every(id => typeof id === 'string'))
+  ) {
+    throw new Error('The configuration contains an invalid calendar selection.');
+  }
+
+  return value as unknown as CalendarConfigFile;
+};
+
+const restoreNotionCalendar = (calendar: PortableNotionCalendar): NotionScrapedCalendar => ({
+  ...calendar,
+  metadata: calendar.metadata
+    ? {
+        ...calendar.metadata,
+        lastScraped: new Date(0),
+        eventCount: 0,
+      }
+    : undefined,
+});
+
+const downloadJson = (data: CalendarConfigFile): void => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `family-calendar-config-${new Date().toISOString().split('T')[0]}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
+class CalendarConfigManager {
+  async createConfig(): Promise<CalendarConfigFile> {
+    const [icalCalendars, notionCalendars, notionToken, notionDatabaseId] = await Promise.all([
+      calendarStorageService.getAllCalendars(),
+      notionScrapedEventsStorage.getAllCalendars(),
+      settingsStorageService.getValue(NOTION_TOKEN_KEY),
+      settingsStorageService.getValue(NOTION_DATABASE_ID_KEY),
+    ]);
+
+    const selectedCalendarIdsValue = safeLocalStorage.getItem(SELECTED_CALENDARS_KEY);
+    let selectedCalendarIds: string[] | undefined;
+    if (selectedCalendarIdsValue) {
+      try {
+        const parsed = JSON.parse(selectedCalendarIdsValue);
+        if (Array.isArray(parsed) && parsed.every(id => typeof id === 'string')) {
+          selectedCalendarIds = parsed;
+        }
+      } catch {
+        // Ignore malformed local selection data rather than blocking export.
+      }
+    }
+
+    return {
+      type: CONFIG_TYPE,
+      version: CONFIG_VERSION,
+      exportDate: new Date().toISOString(),
+      icalCalendars: icalCalendars.map(sanitizeICalCalendar),
+      notionCalendars: notionCalendars.map(sanitizeNotionCalendar),
+      settings: { notionToken, notionDatabaseId },
+      selectedCalendarIds,
+    };
+  }
+
+  async exportCalendarConfig(): Promise<void> {
+    downloadJson(await this.createConfig());
+  }
+
+  async importCalendarConfig(file: File): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await file.text());
+    } catch {
+      throw new Error('Failed to parse the calendar configuration file.');
+    }
+
+    const config = parseCalendarConfig(parsed);
+    const notionCalendars = config.notionCalendars.map(restoreNotionCalendar);
+
+    await calendarStorageService.replaceAllCalendars(config.icalCalendars);
+    await notionScrapedEventsStorage.replaceAllCalendars(notionCalendars);
+
+    await this.restoreSetting(NOTION_TOKEN_KEY, config.settings.notionToken);
+    await this.restoreSetting(NOTION_DATABASE_ID_KEY, config.settings.notionDatabaseId);
+
+    if (config.selectedCalendarIds) {
+      safeLocalStorage.setItem(
+        SELECTED_CALENDARS_KEY,
+        JSON.stringify(config.selectedCalendarIds)
+      );
+    }
+  }
+
+  private async restoreSetting(key: string, value: string | null): Promise<void> {
+    if (value === null) {
+      await settingsStorageService.removeValue(key);
+      return;
+    }
+    await settingsStorageService.setValue(key, value);
+  }
+}
+
+export const calendarConfigManager = new CalendarConfigManager();


### PR DESCRIPTION
# Summary
Add config-only export/import for calendar URLs and Notion API settings
Validate imports and replace existing calendar configuration
Exclude event data and transient sync metadata
Warn users that exported API tokens are stored as plaintext
Add storage helpers and unit tests

## Testing
102 tests passing
ESLint passing
Production build successful